### PR TITLE
Addresses bug in issue #5 of withdraw fee hard-coded to 0.0001

### DIFF
--- a/app/controllers/concerns/withdraws/withdrawable.rb
+++ b/app/controllers/concerns/withdraws/withdrawable.rb
@@ -41,6 +41,7 @@ module Withdraws
     end
 
     def withdraw_params
+      params[:withdraw][:fee] = channel.fee
       params[:withdraw][:currency] = channel.currency
       params[:withdraw][:member_id] = current_user.id
       params.require(:withdraw).permit(:fund_source, :member_id, :currency, :sum)

--- a/app/models/concerns/withdraws/coinable.rb
+++ b/app/models/concerns/withdraws/coinable.rb
@@ -3,7 +3,7 @@ module Withdraws
     extend ActiveSupport::Concern
 
     def set_fee
-      self.fee = "0.0001".to_d
+      self.fee = self.channel.fee
     end
 
     def blockchain_url


### PR DESCRIPTION
The issue here is that the withdraw fee was hard-coded to 0.0001 and this value was used no matter which coin was being withdrawn and ignoring any configuration in config/withdraw_channels.yml.

This fix addresses the issue at two locations in the code.

First, in app/controllers/concerns/withdraws/withdrawable.rb the fee is added to the params hash used during Withdraw object construction. This takes care of the value early on, when creating database record and so the website has a value and so-forth, before the actual withdraw has happened.

Second, during the actual withdraw, `set_fee` from app/models/concerns/withdraws/coinable.rb is invoked to calculate the fee to subtract from the withdraw amount and send to the coin daemon. Here we replace the hard-coded `0.0001` with `self.channel.fee` which supplies the correct value for withdraw calculations.